### PR TITLE
Lesson TOC and minor UI changes

### DIFF
--- a/src/lib/components/Achievement.svelte
+++ b/src/lib/components/Achievement.svelte
@@ -3,15 +3,15 @@
   export let dueDate = true;
 </script>
 
-<section id="achievement" class='achievement'>
+<section id="achievement" class="achievement">
   <h2>Today's Achievement</h2>
   {#if dueDate}
-  <p>Due today at 8pm in Brightspace.</p>
+    <p>Due today at 8pm in Brightspace.</p>
   {/if}
 
-  {#if status === 'announced' || status === 'published'}
-  <slot />
+  {#if status === "announced" || status === "published"}
+    <slot />
   {:else}
-  <p>To be announced</p>
+    <p>To be announced</p>
   {/if}
 </section>

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -5,7 +5,7 @@
 
 <footer>
   <section
-    class="flex flex-col lg:flex-row gap-4 justify-between lg:justify-around mt-3 lg:mt-6 container lg:mx-auto mx-4 mb-4 lg:mb-0"
+    class="flex flex-col lg:flex-row gap-4 justify-between lg:w-4/6 mt-3 lg:mt-6 container lg:mx-auto mx-4 mb-4 lg:mb-0"
   >
     <MainNav />
     <nav>

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -7,7 +7,7 @@
   <section
     class="flex flex-col lg:flex-row gap-4 justify-between lg:w-4/6 mt-3 lg:mt-6 container lg:mx-auto mx-4 mb-4 lg:mb-0"
   >
-    <MainNav />
+    <MainNav styles="flex-col" />
     <nav>
       <ul>
         <li>

--- a/src/lib/components/MainNav.svelte
+++ b/src/lib/components/MainNav.svelte
@@ -1,18 +1,20 @@
 <script>
-	import { navItems } from '$lib/config'
-	import { isMenuOpen } from '$lib/assets/js/store'
-	import NavItem from './NavItem.svelte'
-	import HamburgerMenuButton from './HamburgerMenuButton.svelte'
+  import {navItems} from "$lib/config";
+  import {isMenuOpen} from "$lib/assets/js/store";
+  import NavItem from "./NavItem.svelte";
+  import HamburgerMenuButton from "./HamburgerMenuButton.svelte";
+
+  export let styles = "flex-row";
 </script>
 
 <!-- Contents of this file will be used in the header and the responsive hamburger menu. -->
-<nav class="main-nav" class:open={$isMenuOpen}>
-	<ul>
-		{#each navItems as page}
-		<NavItem href={page.route}>
-			{page.title}
-		</NavItem>
-		{/each}
-	</ul>
-	<HamburgerMenuButton closeOnly="true" />
+<nav class:open={$isMenuOpen}>
+  <ul class="flex flex-wrap {styles}">
+    {#each navItems as page}
+      <NavItem href={page.route}>
+        {page.title}
+      </NavItem>
+    {/each}
+  </ul>
+  <HamburgerMenuButton closeOnly="true" />
 </nav>

--- a/src/lib/content/courses/dsgn-270/01-day-1.md
+++ b/src/lib/content/courses/dsgn-270/01-day-1.md
@@ -1,7 +1,7 @@
 ---
-title: 
-excerpt: 
-status: draft
+title: Day 1
+excerpt: Making designs n stuff
+status: published
 ---
 
 <script>
@@ -12,18 +12,18 @@ status: draft
 
 <Homework {status}>
 
-## Prep
 
 </Homework>
 
 <LessonPlan {status}>
 
-## Housekeeping
+<h2 class="h2"> Housekeeping</h2>
 
 ---
 
-## Topic 1
-
+<h2 class="h2">Topic 1</h2>
+Scramble Bamble
+<h2 class="h2">Topic 2 </h2>
 </LessonPlan>
 
 <Achievement {status}>

--- a/src/lib/content/courses/dsgn-270/01-day-1.md
+++ b/src/lib/content/courses/dsgn-270/01-day-1.md
@@ -17,13 +17,13 @@ status: published
 
 <LessonPlan {status}>
 
-<h2 class="h2"> Housekeeping</h2>
+<h2>Housekeeping</h2>
 
 ---
 
-<h2 class="h2">Topic 1</h2>
+<h2>Topic 1</h2>
 Scramble Bamble
-<h2 class="h2">Topic 2 </h2>
+<h2>Topic 2 </h2>
 </LessonPlan>
 
 <Achievement {status}>

--- a/src/lib/content/courses/dsgn-270/01-day-1.md
+++ b/src/lib/content/courses/dsgn-270/01-day-1.md
@@ -22,8 +22,9 @@ status: published
 ---
 
 <h2>Topic 1</h2>
-Scramble Bamble
-<h2>Topic 2 </h2>
+This is some text
+<h2>Topic 2</h2>
+More text
 </LessonPlan>
 
 <Achievement {status}>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -51,7 +51,7 @@
   </svelte:fragment>
 
   <svelte:fragment slot="sidebarLeft">
-    <nav class="ml-4 mr-8 hidden md:block">
+    <nav class="ml-4 mr-8 hidden md:block md:mr-20 lg:mr-8 mt-6">
       <h3 class="h3">Courses</h3>
       <ul class="list">
         {#each $courses as course}
@@ -61,7 +61,7 @@
               target="_self"
               class="p-2 hover:bg-primary-800/20 block rounded-md transition duration-150 ease-linear"
               ><h4 class="">{course.codeLabel}</h4>
-              <p>{course.title}</p>
+              <p class="hidden lg:block">{course.title}</p>
             </a>
           </li>
         {/each}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -61,7 +61,7 @@
               target="_self"
               class="p-2 hover:bg-primary-800/20 block rounded-md transition duration-150 ease-linear"
               ><h4 class="">{course.codeLabel}</h4>
-              <p class="hidden lg:block">{course.title}</p>
+              <p class="hidden xl:block">{course.title}</p>
             </a>
           </li>
         {/each}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -45,7 +45,7 @@
         </a>
       </svelte:fragment>
       <svelte:fragment slot="trail">
-        <MainNav />
+        <MainNav styles="gap-4" />
       </svelte:fragment>
     </AppBar>
   </svelte:fragment>

--- a/src/routes/courses/[code]/day-[day]/+page.svelte
+++ b/src/routes/courses/[code]/day-[day]/+page.svelte
@@ -8,15 +8,15 @@
   const lesson = $lessonsById[`${$page.params.code}/${$page.params.day}`];
 </script>
 
-<nav class="page-nav">
-  <ul class="flex justify-around">
+<nav class="page-nav my-6 container mx-auto">
+  <ul class="flex justify-between">
     {#if lesson.prev}
       <li><a href="/courses/{lesson.prev}">Prev</a></li>
     {:else}
       <li><span>Prev</span></li>
     {/if}
     <li>
-      <time datetime={lesson.date}>{dayjs(lesson.date).format("dddd, MMM D")}</time>
+      <time datetime={lesson.date}><strong>{dayjs(lesson.date).format("dddd, MMM D")}</strong></time>
     </li>
     {#if lesson.next}
       <li><a href="/courses/{lesson.next}">Next</a></li>
@@ -34,10 +34,10 @@
   <header>
     <h1>{lesson.title}</h1>
   </header>
-  <div class="flex">
-    <article>
+  <div class="flex justify-between">
+    <article class="mx-auto container">
       {@html data.lessonContent}
     </article>
-    <TableOfContents allowedHeadings="h2" />
+    <TableOfContents allowedHeadings="h2" class="hidden lg:block" />
   </div>
 {/if}

--- a/src/routes/courses/[code]/day-[day]/+page.svelte
+++ b/src/routes/courses/[code]/day-[day]/+page.svelte
@@ -8,15 +8,16 @@
   const lesson = $lessonsById[`${$page.params.code}/${$page.params.day}`];
 </script>
 
-<nav class="page-nav my-6 container mx-auto">
-  <ul class="flex justify-between">
+<nav class=" page-nav my-6 container lg:mx-auto">
+  <ul class="flex justify-around lg:justify-between">
     {#if lesson.prev}
       <li><a href="/courses/{lesson.prev}" class="btn variant-filled rounded-md">Prev</a></li>
     {:else}
       <li><a href="/courses/{lesson.prev}" class="btn variant-outline rounded-md">Prev</a></li>
     {/if}
-    <li>
+    <li class="text-center">
       <time datetime={lesson.date}><strong>{dayjs(lesson.date).format("dddd, MMM D")}</strong></time>
+      <p>{lesson.codeLabel} - Day {lesson.day}</p>
     </li>
     {#if lesson.next}
       <li><a href="/courses/{lesson.prev}" class="btn variant-filled rounded-md">Next</a></li>
@@ -26,17 +27,16 @@
   </ul>
 </nav>
 
-<p>{lesson.codeLabel} - Day {lesson.day}</p>
 {#if lesson.status === "draft"}
   <h1>To be Announced</h1>
   <p>This lesson has not been released.</p>
 {:else}
-  <header class="my-4 lg:my-6">
+  <header class="my-4 lg:my-6 mx-4 lg:mx-auto">
     <h1 class="h1 mb-2">{lesson.title}</h1>
     <p>{lesson.excerpt}</p>
   </header>
   <div class="flex justify-between">
-    <article class="mx-auto container">
+    <article class="mx-4 lg:mx-auto container">
       {@html data.lessonContent}
     </article>
     <TableOfContents allowedHeadings="h2" rounded="rounded-md" active="bg-primary-800/20" class="hidden lg:block" />

--- a/src/routes/courses/[code]/day-[day]/+page.svelte
+++ b/src/routes/courses/[code]/day-[day]/+page.svelte
@@ -1,34 +1,43 @@
 <script>
-  import { page }  from '$app/stores';
-  import { lessonsById } from "$lib/stores";
-  import dayjs from 'dayjs';
+  import {TableOfContents} from "@skeletonlabs/skeleton";
+  import {page} from "$app/stores";
+  import {lessonsById} from "$lib/stores";
+  import dayjs from "dayjs";
   export let data;
 
   const lesson = $lessonsById[`${$page.params.code}/${$page.params.day}`];
 </script>
+
 <nav class="page-nav">
-  <ul>
+  <ul class="flex justify-around">
     {#if lesson.prev}
-    <li><a href="/courses/{lesson.prev}">Prev</a></li>
+      <li><a href="/courses/{lesson.prev}">Prev</a></li>
     {:else}
-    <li><span>Prev</span></li>
+      <li><span>Prev</span></li>
     {/if}
     <li>
-      <time datetime={lesson.date}>{dayjs(lesson.date).format('dddd, MMM D')}</time>
+      <time datetime={lesson.date}>{dayjs(lesson.date).format("dddd, MMM D")}</time>
     </li>
     {#if lesson.next}
-    <li><a href="/courses/{lesson.next}">Next</a></li>
+      <li><a href="/courses/{lesson.next}">Next</a></li>
     {:else}
-    <li><span>Next</span></li>
-    {/if}  
+      <li><span>Next</span></li>
+    {/if}
   </ul>
 </nav>
 
 <p>{lesson.codeLabel} - Day {lesson.day}</p>
-{#if lesson.status === 'draft'}
-<h1>To be Announced</h1>
-<p>This lesson has not been released.</p>
+{#if lesson.status === "draft"}
+  <h1>To be Announced</h1>
+  <p>This lesson has not been released.</p>
 {:else}
-<h1>{lesson.title}</h1>
-{@html data.lessonContent}
+  <header>
+    <h1>{lesson.title}</h1>
+  </header>
+  <div class="flex">
+    <article>
+      {@html data.lessonContent}
+    </article>
+    <TableOfContents allowedHeadings="h2" />
+  </div>
 {/if}

--- a/src/routes/courses/[code]/day-[day]/+page.svelte
+++ b/src/routes/courses/[code]/day-[day]/+page.svelte
@@ -11,17 +11,17 @@
 <nav class="page-nav my-6 container mx-auto">
   <ul class="flex justify-between">
     {#if lesson.prev}
-      <li><a href="/courses/{lesson.prev}">Prev</a></li>
+      <li><a href="/courses/{lesson.prev}" class="btn variant-filled rounded-md">Prev</a></li>
     {:else}
-      <li><span>Prev</span></li>
+      <li><a href="/courses/{lesson.prev}" class="btn variant-outline rounded-md">Prev</a></li>
     {/if}
     <li>
       <time datetime={lesson.date}><strong>{dayjs(lesson.date).format("dddd, MMM D")}</strong></time>
     </li>
     {#if lesson.next}
-      <li><a href="/courses/{lesson.next}">Next</a></li>
+      <li><a href="/courses/{lesson.prev}" class="btn variant-filled rounded-md">Next</a></li>
     {:else}
-      <li><span>Next</span></li>
+      <li><span class="btn varient-outline rounded-md">Next</span></li>
     {/if}
   </ul>
 </nav>
@@ -31,13 +31,14 @@
   <h1>To be Announced</h1>
   <p>This lesson has not been released.</p>
 {:else}
-  <header>
-    <h1>{lesson.title}</h1>
+  <header class="my-4 lg:my-6">
+    <h1 class="h1 mb-2">{lesson.title}</h1>
+    <p>{lesson.excerpt}</p>
   </header>
   <div class="flex justify-between">
     <article class="mx-auto container">
       {@html data.lessonContent}
     </article>
-    <TableOfContents allowedHeadings="h2" class="hidden lg:block" />
+    <TableOfContents allowedHeadings="h2" rounded="rounded-md" active="bg-primary-800/20" class="hidden lg:block" />
   </div>
 {/if}


### PR DESCRIPTION
Closes #9

This adds the table of contents along with some styling on pagination links, lesson plan header and tweaks to the global sidebar.

There are link icons being rendered for using html headings in markdown which we might need to address. but this solves MVP of #9 